### PR TITLE
Fix logger TypeError for Python 3.8 API change

### DIFF
--- a/src/flask_state/utils/logger.py
+++ b/src/flask_state/utils/logger.py
@@ -22,7 +22,7 @@ class LoggingWrap:
     def __init__(self):
         self.logger = None
 
-    def find_caller(self, stack_info=False):
+    def find_caller(self, stack_info=False, stacklevel=1):
         """
         Overwrite
         Find the stack frame of the caller so that we can note the source


### PR DESCRIPTION
Fix logger error `TypeError: findCaller() takes from 1 to 2 positional arguments but 3 were given` when running with Python 3.8.