### PR TITLE
style: remove SQLALCHEMY_TRACK_MODIFICATIONS config

### DIFF
--- a/src/flask_state/controller/manager.py
+++ b/src/flask_state/controller/manager.py
@@ -72,7 +72,6 @@ def init_redis(app):
 
 
 def init_db(app):
-    app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = True
     if not app.config.get("SQLALCHEMY_BINDS", {}).get(Constant.DEFAULT_BIND_SQLITE):
         raise KeyError(ErrorMsg.LACK_SQLITE.get_msg())
     app.config["SQLALCHEMY_BINDS"][Constant.DEFAULT_BIND_SQLITE] = format_address(


### PR DESCRIPTION
Since enable SQLALCHEMY_TRACK_MODIFICATIONS will **use extra memory resources** <br>
user needs to know this info, though it will throws a warning. <br>
It currently defaults to `True` in Flask-SQLAlchemy v2.x, and will become `False` in v3.x.
> Ref: [How do I know if I can disable SQLALCHEMY_TRACK_MODIFICATIONS?](https://stackoverflow.com/questions/33738467/how-do-i-know-if-i-can-disable-sqlalchemy-track-modifications/33790196#33790196)
